### PR TITLE
maildev/maildev instead of soulteary/maildev, that is not updated for a year

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,10 +196,10 @@
 <p><img src="https://github.com/maildev/maildev/blob/gh-pages/images/screenshot-2021-01-03.png?raw=true" alt="MailDev Screenshot"></p>
 <h2 id="docker-run">Docker Run</h2>
 <p>If you want to use MailDev with <a href="https://www.docker.com/">Docker</a>, you can use the
-<a href="https://hub.docker.com/r/soulteary/maildev"><strong>soulteary/maildev</strong> image on Docker Hub</a>.
+<a href="https://hub.docker.com/r/maildev/maildev"><strong>maildev/maildev</strong> image on Docker Hub</a>.
 For a guide for usage with Docker,
 <a href="https://github.com/maildev/maildev/blob/master/docs/docker.md">checkout the docs</a>.</p>
-<pre><code>$ docker run -p 1080:1080 -p 1025:1025 soulteary/maildev
+<pre><code>$ docker run -p 1080:1080 -p 1025:1025 maildev/maildev
 </code></pre>
 <h2 id="usage">Usage</h2>
 <pre><code>Usage: maildev [options]


### PR DESCRIPTION
On https://maildev.github.io/maildev/

show `maildev/maildev` instead of `soulteary/maildev`, that is not updated for a year.

Compare 

- https://hub.docker.com/r/maildev/maildev/tags
- https://hub.docker.com/r/soulteary/maildev/tags